### PR TITLE
PR#13 bugged free transaction feature

### DIFF
--- a/src/serviceImpl/TransactionImpl.java
+++ b/src/serviceImpl/TransactionImpl.java
@@ -54,13 +54,14 @@ public class TransactionImpl implements Transaction {
             transactionModel.currentBalance = getBalance();
             balance = prevBalance + amount;
         } else {
+            transactionModel.currentBalance = getBalance();
             setBalance(amount);
+
         }
         transactionModel.date = LocalDate.now().toString();
         transactionModel.time = LocalDateTime.now().toLocalTime().toString();
         transactionModel.transactionName = "Deposit";
         transactionModel.transactionAmount = amount;
-        transactionModel.currentBalance = getBalance();
         transactionModel.newBalance = getBalance();
 
         histories.add(transactionModel);


### PR DESCRIPTION
While depositing money, In transaction history, If the account has 0 balance, the user is seeing a deposited balance as the previous balance, If the account has 0 balance then in the previous-balance column it should be 0, this feature is fixed.